### PR TITLE
Add Vedika API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Awesome OpenAPI is a curated list of public OpenAPI endpoints.
 - [Vercel](https://openapi.vercel.sh/)
 - [Zoom](https://developers.zoom.us/api-specs/zoom-api/methods/ZoomMeetingAPI-spec.json)
 - [Midday](https://engine.midday.ai/openapi)
+
+* [Vedika API](https://vedika.io) - Vedic astrology API with OpenAPI spec


### PR DESCRIPTION
Adding Vedika - has OpenAPI 3.0 spec.

- Website: https://vedika.io