### PR TITLE
Add Warnely

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Awesome OpenAPI is a curated list of public OpenAPI endpoints.
 - [Vercel](https://openapi.vercel.sh/)
 - [Zoom](https://developers.zoom.us/api-specs/zoom-api/methods/ZoomMeetingAPI-spec.json)
 - [Midday](https://engine.midday.ai/openapi)
+- [Warnely](https://warnely.com/openapi.json)


### PR DESCRIPTION
Adds [Warnely](https://warnely.com/openapi.json) — a public OpenAPI 3.1 endpoint for the Warnely travel-safety REST API (180 countries, free, CC BY 4.0).