### PR TITLE
Add BrewPage OpenAPI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Awesome OpenAPI is a curated list of public OpenAPI endpoints.
 
 - [Bitbucket](https://dac-static.atlassian.com/cloud/bitbucket/swagger.v3.json?_v=2.300.49-0.1308.0)
+- [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/openapi.json)
 - [Documenso](https://app.documenso.com/api/v1/openapi)
 - [Intercom](https://developers.intercom.com/_spec/docs/references/@2.11/rest-api/api.intercom.io.json)
 - [HuggingFace](https://api.endpoints.huggingface.cloud/openapi.json)


### PR DESCRIPTION
Adding BrewPage to the list of public OpenAPI endpoints.

**Spec:** https://kochetkov-ma.github.io/brewpage-openapi/openapi.json (OpenAPI 3.1)
**Docs site:** https://kochetkov-ma.github.io/brewpage-openapi/
**Source repo:** https://github.com/kochetkov-ma/brewpage-openapi
**Product:** https://brewpage.app — free HTML/Markdown/KV/JSON/file hosting platform with short URLs, no signup.

The endpoint is publicly reachable (HTTPS, no auth required for reads, CORS-enabled), serves OpenAPI 3.1 with `info.termsOfService` and `externalDocs` populated. Entry placed alphabetically between Bitbucket and Documenso.