### PR TITLE
Add Block Lottos OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Awesome OpenAPI is a curated list of public OpenAPI endpoints.
 
 - [Bitbucket](https://dac-static.atlassian.com/cloud/bitbucket/swagger.v3.json?_v=2.300.49-0.1308.0)
+- [Block Lottos](https://blocklottos.com/openapi.json)
 - [Documenso](https://app.documenso.com/api/v1/openapi)
 - [Intercom](https://developers.intercom.com/_spec/docs/references/@2.11/rest-api/api.intercom.io.json)
 - [HuggingFace](https://api.endpoints.huggingface.cloud/openapi.json)


### PR DESCRIPTION
Adds the Block Lottos public OpenAPI endpoint to the list.

Verification:
- `https://blocklottos.com/openapi.json` returns HTTP 200
- Spec parses as OpenAPI 3.1.0
- The spec currently exposes 15 paths for lottery stats, jackpot, draw history, wallet ticket lookups, prize checks, advertising, and wallet-signed ticket transaction builders