### PR TITLE
Add CruiseFeed OpenAPI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Awesome OpenAPI is a curated list of public OpenAPI endpoints.
 
 - [Bitbucket](https://dac-static.atlassian.com/cloud/bitbucket/swagger.v3.json?_v=2.300.49-0.1308.0)
+- [CruiseFeed](https://api.cruisefeed.io/openapi.json)
 - [Documenso](https://app.documenso.com/api/v1/openapi)
 - [Intercom](https://developers.intercom.com/_spec/docs/references/@2.11/rest-api/api.intercom.io.json)
 - [HuggingFace](https://api.endpoints.huggingface.cloud/openapi.json)


### PR DESCRIPTION
Adds [CruiseFeed](https://cruisefeed.io) to the list — a public OpenAPI 3.1 endpoint for cruise inventory & pricing data (lines, ships, sailings, ports, itineraries).

Spec: https://api.cruisefeed.io/openapi.json · Docs: https://api.cruisefeed.io/docs